### PR TITLE
Move observability extension from ballerina-lang to ballerina-observability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,14 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Ignore everything in this directory
+target
+.classpath
+.settings
+.project
+*.iml
+*.iws
+*.ipr
+.idea
+.m2

--- a/metrics-extensions/pom.xml
+++ b/metrics-extensions/pom.xml
@@ -1,0 +1,41 @@
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.ballerinalang</groupId>
+        <artifactId>ballerina-observability-parent</artifactId>
+        <version>0.970.0-alpha1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>metrics-extensions</artifactId>
+    <packaging>pom</packaging>
+    <name>Ballerina - Metrics Extensions - Parent</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+
+    </modules>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,404 @@
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.ballerinalang</groupId>
+    <artifactId>ballerina-observability-parent</artifactId>
+    <packaging>pom</packaging>
+    <version>0.970.0-alpha1-SNAPSHOT</version>
+    <name>Ballerina Observability - Parent</name>
+
+    <description>
+        This contains various (tracing, metrics, logging) extensions that can be used with Ballerina Observability.
+    </description>
+    <url>http://ballerinalang.org/</url>
+    <organization>
+        <name>WSO2</name>
+        <url>http://www.wso2.org/</url>
+    </organization>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Ballerina Developer</name>
+            <email>ballerina-dev@googlegroups.com</email>
+            <organization>WSO2</organization>
+            <organizationUrl>http://www.wso2.org/</organizationUrl>
+        </developer>
+    </developers>
+
+    <mailingLists>
+        <mailingList>
+            <name>Ballerina Dev List</name>
+            <post>ballerina-dev@googlegroups.com</post>
+        </mailingList>
+    </mailingLists>
+
+    <scm>
+        <url>https://github.com/ballerina-platform/ballerina-observability.git</url>
+        <developerConnection>scm:git:https://github.com/ballerina-platform/ballerina-observability.git
+        </developerConnection>
+        <connection>scm:git:https://github.com/ballerina-platform/ballerina-observability.git</connection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <repositories>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 Releases Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+        <repository>
+            <id>wso2.snapshots</id>
+            <name>WSO2 Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>wso2.releases</id>
+            <name>WSO2 Releases Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </pluginRepository>
+        <pluginRepository>
+            <id>wso2.snapshots</id>
+            <name>WSO2 Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </pluginRepository>
+        <pluginRepository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <distributionManagement>
+        <repository>
+            <id>nexus-releases</id>
+            <name>WSO2 Nexus Release Repository</name>
+            <url>http://maven.wso2.org/nexus/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <snapshotRepository>
+            <id>wso2.snapshots</id>
+            <name>WSO2 Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.ballerinalang</groupId>
+                <artifactId>ballerina-core</artifactId>
+                <version>${ballerina.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing</groupId>
+                <artifactId>opentracing-api</artifactId>
+                <version>${open.tracing.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.uber.jaeger</groupId>
+                <artifactId>jaeger-core</artifactId>
+                <version>${jaeger.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.uber.jaeger</groupId>
+                <artifactId>jaeger-thrift</artifactId>
+                <version>${jaeger.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.thrift</groupId>
+                <artifactId>libthrift</artifactId>
+                <version>${libthrift.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${okhttp.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio</artifactId>
+                <version>${okio.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <modules>
+        <module>metrics-extensions</module>
+        <module>tracing-extensions</module>
+    </modules>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>metrics-extensions</module>
+                <module>tracing-extensions</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>wso2-release</id>
+            <build>
+                <plugins>
+                    <!-- We want to deploy the artifact to a staging location for perusal -->
+                    <plugin>
+                        <inherited>true</inherited>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <updateReleaseInfo>true</updateReleaseInfo>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- We want to sign the artifact, the POM, and all attached artifacts -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>${maven.wagon.ssh.version}</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven.release.plugin.version}</version>
+                <configuration>
+                    <preparationGoals>clean install</preparationGoals>
+                    <autoVersionSubmodules>false</autoVersionSubmodules>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>${maven.deploy.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <source>${wso2.maven.compiler.source}</source>
+                    <target>${wso2.maven.compiler.target}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven.failsafe.plugin.version}</version>
+            </plugin>
+            <plugin><!-- Overridden from parent pom to exclude generated sources -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <configuration>
+                    <effort>Max</effort>
+                    <threshold>Low</threshold>
+                    <xmlOutput>true</xmlOutput>
+                    <findbugsXmlOutputDirectory>
+                        ${project.build.directory}/findbugs
+                    </findbugsXmlOutputDirectory>
+                    <excludeFilterFile>${maven.findbugsplugin.version.exclude}</excludeFilterFile>
+                </configuration>
+                <version>${maven.findbugsplugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>analyze-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin><!-- Overridden from parent pom to exclude generated sources -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven.checkstyle.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <configuration>
+                            <configLocation>
+                                https://raw.githubusercontent.com/wso2/code-quality-tools/master/checkstyle/checkstyle.xml
+                            </configLocation>
+                            <suppressionsLocation>
+                                https://raw.githubusercontent.com/wso2/code-quality-tools/master/checkstyle/suppressions.xml
+                            </suppressionsLocation>
+                            <encoding>UTF-8</encoding>
+                            <consoleOutput>true</consoleOutput>
+                            <failsOnError>true</failsOnError>
+                            <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                            <!--Exclude generated sources-->
+                            <excludes>
+                                **/generated/**
+                            </excludes>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- For ballerina annotation processing -->
+            <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+                <version>${maven.processor.plugin.version}</version>
+                <configuration>
+                    <processors>
+                        <processor>org.ballerinalang.codegen.BallerinaAnnotationProcessor</processor>
+                    </processors>
+                    <options>
+                        <nativeEntityProviderPackage>
+                            org.ballerinalang.net.ftp.generated.providers
+                        </nativeEntityProviderPackage>
+                        <nativeEntityProviderClass>StandardNativeElementProvider</nativeEntityProviderClass>
+                    </options>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>process</id>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-remote-resources-plugin</artifactId>
+                <version>${maven.remote.resource.plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <ballerina.version>0.970.0-alpha1-SNAPSHOT</ballerina.version>
+        <project.scm.id>my-scm-server</project.scm.id>
+        <maven.wagon.ssh.version>2.1</maven.wagon.ssh.version>
+        <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
+        <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
+        <wso2.maven.compiler.source>1.8</wso2.maven.compiler.source>
+        <wso2.maven.compiler.target>1.8</wso2.maven.compiler.target>
+        <maven.findbugsplugin.version>3.0.3</maven.findbugsplugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.plugin.version>3.5.1</maven.compiler.plugin.version>
+        <maven.surefire.plugin.version>2.19.1</maven.surefire.plugin.version>
+        <maven.failsafe.plugin.version>2.19.1</maven.failsafe.plugin.version>
+        <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
+        <maven.dependency.plugin.version>3.0.2</maven.dependency.plugin.version>
+        <maven.processor.plugin.version>2.2.4</maven.processor.plugin.version>
+        <maven.remote.resource.plugin.version>1.5</maven.remote.resource.plugin.version>
+        <maven.findbugsplugin.version.exclude>findbugs-exclude.xml</maven.findbugsplugin.version.exclude>
+
+        <open.tracing.version>0.31.0</open.tracing.version>
+        <jaeger.version>0.24.0</jaeger.version>
+        <libthrift.version>0.10.0</libthrift.version>
+        <okhttp.version>3.9.1</okhttp.version>
+        <okio.version>1.13.0</okio.version>
+    </properties>
+
+</project>

--- a/tracing-extensions/LICENSE
+++ b/tracing-extensions/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tracing-extensions/modules/ballerina-jaeger-extension/README.md
+++ b/tracing-extensions/modules/ballerina-jaeger-extension/README.md
@@ -1,0 +1,40 @@
+### Ballerina Jaeger Extension
+
+##### Install Guide
+
+- Start Jaeger. You can use their docker image using following command. `docker run -d -p5775:5775/udp 
+-p6831:6831/udp -p6832:6832/udp -p5778:5778 -p16686:16686 -p14268:14268 
+jaegertracing/all-in-one:latest`.
+- Build `ballerina-jaeger-extension` and put it in `bre/lib/` directory.
+- Download following jar files and place them in `bre/lib/` directory.
+  - [jaeger-core-0.24.0.jar] [1]
+  - [jaeger-thrift-0.24.0.jar] [2]
+  - [libthrift-0.11.0.jar] [3]
+  - [okhttp-3.9.1.jar] [4]
+  - [okio-1.13.0.jar] [5]
+- Create a `trace-config.yaml` with following properties.
+```yaml
+tracers:
+  - name: jaeger
+    enabled: true
+    className: org.ballerinalang.observe.trace.extension.jaeger.OpenTracingExtension
+    configuration:
+      sampler.type: const
+      sampler.param: 1
+      reporter.log.spans: true
+      reporter.hostname: localhost
+      reporter.port: 5775
+      reporter.flush.interval.ms: 1000
+      reporter.max.buffer.spans: 1000
+```
+- Create a `ballerina.conf` file with `trace.config` property, which points to the above `trace-config.yaml`.
+- Run your Ballerina service with that `ballerina.conf` file.
+  - Either place `ballerina.conf` in your applications directory.
+  - Or use `-Bballerina.conf=path/to/ballerina.conf`
+- Once everything is up and running, you can use jaeger dashboard to view traces.
+
+[1]: http://central.maven.org/maven2/com/uber/jaeger/jaeger-core/0.24.0/jaeger-core-0.24.0.jar
+[2]: http://central.maven.org/maven2/com/uber/jaeger/jaeger-thrift/0.24.0/jaeger-thrift-0.24.0.jar
+[3]: http://central.maven.org/maven2/org/apache/thrift/libthrift/0.11.0/libthrift-0.11.0.jar
+[4]: http://central.maven.org/maven2/com/squareup/okhttp3/okhttp/3.9.1/okhttp-3.9.1.jar
+[5]: http://central.maven.org/maven2/com/squareup/okio/okio/1.13.0/okio-1.13.0.jar

--- a/tracing-extensions/modules/ballerina-jaeger-extension/findbugs-exclude.xml
+++ b/tracing-extensions/modules/ballerina-jaeger-extension/findbugs-exclude.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter>
+
+</FindBugsFilter>

--- a/tracing-extensions/modules/ballerina-jaeger-extension/pom.xml
+++ b/tracing-extensions/modules/ballerina-jaeger-extension/pom.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>tracing-extensions</artifactId>
+        <groupId>org.ballerinalang</groupId>
+        <version>0.970.0-alpha1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>ballerina-jaeger-extension</artifactId>
+    <name>Ballerina - Jaeger Tracing Extension</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.ballerinalang</groupId>
+            <artifactId>ballerina-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.uber.jaeger</groupId>
+            <artifactId>jaeger-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.uber.jaeger</groupId>
+            <artifactId>jaeger-thrift</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven.dependency.plugin.version}</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>${project.artifactId}</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>${project.packaging}</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.uber.jaeger</groupId>
+                                    <artifactId>jaeger-core</artifactId>
+                                    <version>${jaeger.version}</version>
+                                    <type>${project.packaging}</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.uber.jaeger</groupId>
+                                    <artifactId>jaeger-thrift</artifactId>
+                                    <version>${jaeger.version}</version>
+                                    <type>${project.packaging}</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.thrift</groupId>
+                                    <artifactId>libthrift</artifactId>
+                                    <version>${libthrift.version}</version>
+                                    <type>${project.packaging}</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.squareup.okhttp3</groupId>
+                                    <artifactId>okhttp</artifactId>
+                                    <version>${okhttp.version}</version>
+                                    <type>${project.packaging}</type>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.squareup.okio</groupId>
+                                    <artifactId>okio</artifactId>
+                                    <version>${okio.version}</version>
+                                    <type>${project.packaging}</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.build.directory}/jaeger-extension</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <useBaseVersion>true</useBaseVersion>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/dist.xml</descriptor>
+                    </descriptors>
+                    <finalName>jaeger-extension</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-remote-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <configuration>
+                            <resourceBundles>
+                                <resourceBundle>org.apache:apache-jar-resource-bundle:1.4</resourceBundle>
+                            </resourceBundles>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tracing-extensions/modules/ballerina-jaeger-extension/src/main/assembly/dist.xml
+++ b/tracing-extensions/modules/ballerina-jaeger-extension/src/main/assembly/dist.xml
@@ -1,0 +1,33 @@
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<assembly xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>bin</id>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/jaeger-extension</directory>
+            <outputDirectory>jaeger-extension</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/tracing-extensions/modules/ballerina-jaeger-extension/src/main/java/org/ballerinalang/observe/trace/extension/jaeger/Constants.java
+++ b/tracing-extensions/modules/ballerina-jaeger-extension/src/main/java/org/ballerinalang/observe/trace/extension/jaeger/Constants.java
@@ -1,0 +1,47 @@
+
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.observe.trace.extension.jaeger;
+
+/**
+ * This is the constants class that defines all the constants
+ * that are used by the {@link OpenTracingExtension}.
+ */
+public class Constants {
+    static final String TRACER_NAME = "jaeger";
+    static final String SAMPLER_TYPE_CONFIG = "sampler.type";
+    static final String SAMPLER_PARAM_CONFIG = "sampler.param";
+    static final String REPORTER_LOG_SPANS_CONFIG = "reporter.log.spans";
+    static final String REPORTER_HOST_NAME_CONFIG = "reporter.hostname";
+    static final String REPORTER_PORT_CONFIG = "reporter.port";
+    static final String REPORTER_FLUSH_INTERVAL_MS_CONFIG = "reporter.flush.interval.ms";
+    static final String REPORTER_MAX_BUFFER_SPANS_CONFIG = "reporter.max.buffer.spans";
+    static final String DEFAULT_SAMPLER_TYPE = "const";
+    static final Number DEFAULT_SAMPLER_PARAM = 1;
+    static final boolean DEFAULT_REPORTER_LOG_SPANS = true;
+    static final String DEFAULT_REPORTER_HOSTNAME = "localhost";
+    static final int DEFAULT_REPORTER_PORT = 5775;
+    static final int DEFAULT_REPORTER_FLUSH_INTERVAL = 1000;
+    static final int DEFAULT_REPORTER_MAX_BUFFER_SPANS = 10000;
+
+    private Constants() {
+
+    }
+
+}

--- a/tracing-extensions/modules/ballerina-jaeger-extension/src/main/java/org/ballerinalang/observe/trace/extension/jaeger/NoOpScopeManager.java
+++ b/tracing-extensions/modules/ballerina-jaeger-extension/src/main/java/org/ballerinalang/observe/trace/extension/jaeger/NoOpScopeManager.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.observe.trace.extension.jaeger;
+
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * NoOp implementation of Scope Manager.
+ */
+public class NoOpScopeManager implements ScopeManager {
+
+    static final NoOpScopeManager INSTANCE = new NoOpScopeManager();
+
+    private NoOpScopeManager() {
+    }
+
+    @Override
+    public Scope activate(Span span, boolean finishSpanOnClose) {
+        return NoOpScope.INSTANCE;
+    }
+
+    @Override
+    public Scope active() {
+        return null;
+    }
+
+    static class NoOpScope implements Scope {
+
+        static final NoOpScope INSTANCE = new NoOpScope();
+
+        private NoOpScope() {
+        }
+
+        @Override
+        public void close() {
+
+        }
+
+        @Override
+        public Span span() {
+            return NoOpSpan.INSTANCE;
+        }
+    }
+
+    static class NoOpSpan implements Span {
+
+        static final NoOpSpan INSTANCE = new NoOpSpan();
+
+        private NoOpSpan() {
+        }
+
+        @Override
+        public SpanContext context() {
+            return NoOpSpanContext.INSTANCE;
+        }
+
+        @Override
+        public void finish() {
+        }
+
+        @Override
+        public void finish(long finishMicros) {
+        }
+
+        @Override
+        public NoOpSpan setTag(String key, String value) {
+            return this;
+        }
+
+        @Override
+        public NoOpSpan setTag(String key, boolean value) {
+            return this;
+        }
+
+        @Override
+        public NoOpSpan setTag(String key, Number value) {
+            return this;
+        }
+
+        @Override
+        public NoOpSpan log(Map<String, ?> fields) {
+            return this;
+        }
+
+        @Override
+        public NoOpSpan log(long timestampMicroseconds, Map<String, ?> fields) {
+            return this;
+        }
+
+        @Override
+        public NoOpSpan log(String event) {
+            return this;
+        }
+
+        @Override
+        public NoOpSpan log(long timestampMicroseconds, String event) {
+            return this;
+        }
+
+        @Override
+        public NoOpSpan setBaggageItem(String key, String value) {
+            return this;
+        }
+
+        @Override
+        public String getBaggageItem(String key) {
+            return null;
+        }
+
+        @Override
+        public NoOpSpan setOperationName(String operationName) {
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return NoOpSpan.class.getSimpleName();
+        }
+    }
+
+    static class NoOpSpanContext implements SpanContext {
+
+        static final NoOpSpanContext INSTANCE = new NoOpSpanContext();
+
+        private NoOpSpanContext() {
+        }
+
+        @Override
+        public Iterable<Map.Entry<String, String>> baggageItems() {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/tracing-extensions/modules/ballerina-jaeger-extension/src/main/java/org/ballerinalang/observe/trace/extension/jaeger/OpenTracingExtension.java
+++ b/tracing-extensions/modules/ballerina-jaeger-extension/src/main/java/org/ballerinalang/observe/trace/extension/jaeger/OpenTracingExtension.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.observe.trace.extension.jaeger;
+
+import io.opentracing.Tracer;
+import org.ballerinalang.util.tracer.OpenTracer;
+import org.ballerinalang.util.tracer.exception.InvalidConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+import static org.ballerinalang.observe.trace.extension.jaeger.Constants.DEFAULT_REPORTER_FLUSH_INTERVAL;
+import static org.ballerinalang.observe.trace.extension.jaeger.Constants.DEFAULT_REPORTER_HOSTNAME;
+import static org.ballerinalang.observe.trace.extension.jaeger.Constants.DEFAULT_REPORTER_LOG_SPANS;
+import static org.ballerinalang.observe.trace.extension.jaeger.Constants.DEFAULT_REPORTER_MAX_BUFFER_SPANS;
+import static org.ballerinalang.observe.trace.extension.jaeger.Constants.DEFAULT_REPORTER_PORT;
+import static org.ballerinalang.observe.trace.extension.jaeger.Constants.DEFAULT_SAMPLER_PARAM;
+import static org.ballerinalang.observe.trace.extension.jaeger.Constants.DEFAULT_SAMPLER_TYPE;
+import static org.ballerinalang.observe.trace.extension.jaeger.Constants.REPORTER_FLUSH_INTERVAL_MS_CONFIG;
+import static org.ballerinalang.observe.trace.extension.jaeger.Constants.REPORTER_HOST_NAME_CONFIG;
+import static org.ballerinalang.observe.trace.extension.jaeger.Constants.REPORTER_LOG_SPANS_CONFIG;
+import static org.ballerinalang.observe.trace.extension.jaeger.Constants.REPORTER_MAX_BUFFER_SPANS_CONFIG;
+import static org.ballerinalang.observe.trace.extension.jaeger.Constants.REPORTER_PORT_CONFIG;
+import static org.ballerinalang.observe.trace.extension.jaeger.Constants.SAMPLER_PARAM_CONFIG;
+import static org.ballerinalang.observe.trace.extension.jaeger.Constants.SAMPLER_TYPE_CONFIG;
+import static org.ballerinalang.observe.trace.extension.jaeger.Constants.TRACER_NAME;
+
+/**
+ * This is the open tracing extension class for {@link OpenTracer}.
+ */
+public class OpenTracingExtension implements OpenTracer {
+
+    private static final Logger logger = LoggerFactory.getLogger(OpenTracingExtension.class);
+
+    @Override
+    public Tracer getTracer(String tracerName, Properties configProperties, String serviceName)
+            throws InvalidConfigurationException {
+        if (!tracerName.equalsIgnoreCase(TRACER_NAME)) {
+            throw new InvalidConfigurationException("Unexpected tracer name! " +
+                    "The tracer name supported by this extension is : " + TRACER_NAME + " but found : "
+                    + tracerName);
+        }
+        validateConfiguration(configProperties);
+        return new com.uber.jaeger.Configuration(serviceName,
+                new com.uber.jaeger.Configuration.SamplerConfiguration(
+                        (String) configProperties.get(SAMPLER_TYPE_CONFIG)
+                        , (Integer) configProperties.get(SAMPLER_PARAM_CONFIG)),
+                new com.uber.jaeger.Configuration.ReporterConfiguration(
+                        (Boolean) configProperties.get(REPORTER_LOG_SPANS_CONFIG),
+                        (String) configProperties.get(REPORTER_HOST_NAME_CONFIG),
+                        (Integer) configProperties.get(REPORTER_PORT_CONFIG),
+                        (Integer) configProperties.get(REPORTER_FLUSH_INTERVAL_MS_CONFIG),
+                        (Integer) configProperties.get(REPORTER_MAX_BUFFER_SPANS_CONFIG))
+        ).getTracerBuilder().withScopeManager(NoOpScopeManager.INSTANCE).build();
+    }
+
+    private void validateConfiguration(Properties configuration) {
+        setValidatedStringConfig(configuration, SAMPLER_TYPE_CONFIG, DEFAULT_SAMPLER_TYPE);
+        setValidatedIntegerConfig(configuration, SAMPLER_PARAM_CONFIG, DEFAULT_SAMPLER_PARAM.intValue());
+        setValidatedBooleanConfig(configuration, REPORTER_LOG_SPANS_CONFIG, DEFAULT_REPORTER_LOG_SPANS);
+        setValidatedStringConfig(configuration, REPORTER_HOST_NAME_CONFIG, DEFAULT_REPORTER_HOSTNAME);
+        setValidatedIntegerConfig(configuration, REPORTER_PORT_CONFIG, DEFAULT_REPORTER_PORT);
+        setValidatedIntegerConfig(configuration, REPORTER_FLUSH_INTERVAL_MS_CONFIG, DEFAULT_REPORTER_FLUSH_INTERVAL);
+        setValidatedIntegerConfig(configuration, REPORTER_MAX_BUFFER_SPANS_CONFIG, DEFAULT_REPORTER_MAX_BUFFER_SPANS);
+    }
+
+    private void setValidatedStringConfig(Properties configuration, String configName, String defaultValue) {
+        Object configValue = configuration.get(configName);
+        if (configValue == null || configValue.toString().trim().isEmpty()) {
+            configuration.put(configName, defaultValue);
+        } else {
+            configuration.put(configName, configValue.toString().trim());
+        }
+    }
+
+    private void setValidatedIntegerConfig(Properties configuration, String configName, int defaultValue) {
+        Object configValue = configuration.get(configName);
+        if (configValue == null) {
+            configuration.put(configName, defaultValue);
+        } else {
+            try {
+                configuration.put(configName, Integer.parseInt(configValue.toString()));
+            } catch (NumberFormatException ex) {
+                logger.warn(String.format("Open tracing configuration for tracer name - %s expects " +
+                                "configuration element : %swith integer type but found non integer : %s ! Therefore " +
+                                "assigning default value : %d for %s configuration.", TRACER_NAME, configName,
+                        configValue.toString(), defaultValue, configName));
+                configuration.put(configName, defaultValue);
+            }
+        }
+    }
+
+    private void setValidatedBooleanConfig(Properties configuration, String configName, boolean defaultValue) {
+        Object configValue = configuration.get(configName);
+        if (configValue == null) {
+            configuration.put(configName, defaultValue);
+        } else {
+            String configStringValue = configValue.toString().trim();
+            if (configStringValue.equalsIgnoreCase(Boolean.TRUE.toString())
+                    || configStringValue.equalsIgnoreCase(Boolean.FALSE.toString())) {
+                configuration.put(configName, Boolean.parseBoolean(configStringValue));
+            } else {
+                logger.warn(String.format("Open tracing configuration for tracer name - %s expects " +
+                                "configuration element : %swith boolean type (true/false) but found non boolean :" +
+                                " %s ! Therefore assigning default value : %s for %s configuration.",
+                        TRACER_NAME, configName, configStringValue, defaultValue, configName));
+                configuration.put(configName, defaultValue);
+            }
+        }
+    }
+}

--- a/tracing-extensions/modules/ballerina-noop-extension/README.md
+++ b/tracing-extensions/modules/ballerina-noop-extension/README.md
@@ -1,0 +1,18 @@
+### Ballerina Jaeger Extension
+
+##### Install Guide
+
+- Build `ballerina-noop-extension` and put it in `bre/lib/` directory.
+- Create a `trace-config.yaml` with following properties.
+```yaml
+tracers:
+ - name: noop
+   enabled: true
+   className: org.ballerinalang.observe.trace.extension.noop.OpenTracingExtension
+   configuration:
+     reporter.hostname: localhost
+```
+- Create a `ballerina.conf` file with `trace.config` property, which points to the above `trace-config.yaml`.
+- Run your Ballerina service with that `ballerina.conf` file.
+  - Either place `ballerina.conf` in your applications directory.
+  - Or use `-Bballerina.conf=path/to/ballerina.conf`

--- a/tracing-extensions/modules/ballerina-noop-extension/findbugs-exclude.xml
+++ b/tracing-extensions/modules/ballerina-noop-extension/findbugs-exclude.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter>
+
+</FindBugsFilter>

--- a/tracing-extensions/modules/ballerina-noop-extension/pom.xml
+++ b/tracing-extensions/modules/ballerina-noop-extension/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>tracing-extensions</artifactId>
+        <groupId>org.ballerinalang</groupId>
+        <version>0.970.0-alpha1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>ballerina-noop-extension</artifactId>
+    <name>Ballerina - Noop Tracing Extension</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.ballerinalang</groupId>
+            <artifactId>ballerina-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven.dependency.plugin.version}</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>${project.artifactId}</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>${project.packaging}</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.build.directory}/noop-extension</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <useBaseVersion>true</useBaseVersion>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/dist.xml</descriptor>
+                    </descriptors>
+                    <finalName>noop-extension</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-remote-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <configuration>
+                            <resourceBundles>
+                                <resourceBundle>org.apache:apache-jar-resource-bundle:1.4</resourceBundle>
+                            </resourceBundles>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tracing-extensions/modules/ballerina-noop-extension/src/main/assembly/dist.xml
+++ b/tracing-extensions/modules/ballerina-noop-extension/src/main/assembly/dist.xml
@@ -1,0 +1,33 @@
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<assembly xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>bin</id>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/noop-extension</directory>
+            <outputDirectory>noop-extension</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/tracing-extensions/modules/ballerina-noop-extension/src/main/java/org/ballerinalang/observe/trace/extension/noop/NoopScopeManager.java
+++ b/tracing-extensions/modules/ballerina-noop-extension/src/main/java/org/ballerinalang/observe/trace/extension/noop/NoopScopeManager.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.observe.trace.extension.noop;
+
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+
+/**
+ * A no-op implementation of a ScopeManager.
+ */
+public interface NoopScopeManager extends ScopeManager {
+    NoopScopeManager INSTANCE = new NoopScopeManagerImpl();
+
+    /**
+     * A no-op implementation of a Scope.
+     */
+    interface NoopScope extends Scope {
+        NoopScope INSTANCE = new NoopScopeManagerImpl.NoopScopeImpl();
+    }
+}
+
+class NoopScopeManagerImpl implements NoopScopeManager {
+    @Override
+    public Scope activate(Span span, boolean finishOnClose) {
+        return NoopScope.INSTANCE;
+    }
+
+    @Override
+    public Scope active() {
+        return NoopScope.INSTANCE;
+    }
+
+    static class NoopScopeImpl implements NoopScopeManager.NoopScope {
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public Span span() {
+            return NoopSpan.INSTANCE;
+        }
+    }
+}

--- a/tracing-extensions/modules/ballerina-noop-extension/src/main/java/org/ballerinalang/observe/trace/extension/noop/NoopSpan.java
+++ b/tracing-extensions/modules/ballerina-noop-extension/src/main/java/org/ballerinalang/observe/trace/extension/noop/NoopSpan.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.observe.trace.extension.noop;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+
+import java.util.Map;
+
+/**
+ * A no-op implementation of a Span.
+ */
+public interface NoopSpan extends Span {
+    NoopSpan INSTANCE = new NoopSpanImpl();
+}
+
+final class NoopSpanImpl implements NoopSpan {
+
+    @Override
+    public SpanContext context() {
+        return NoopSpanContextImpl.INSTANCE;
+    }
+
+    @Override
+    public void finish() {
+    }
+
+    @Override
+    public void finish(long finishMicros) {
+    }
+
+    @Override
+    public NoopSpan setTag(String key, String value) {
+        return this;
+    }
+
+    @Override
+    public NoopSpan setTag(String key, boolean value) {
+        return this;
+    }
+
+    @Override
+    public NoopSpan setTag(String key, Number value) {
+        return this;
+    }
+
+    @Override
+    public NoopSpan log(Map<String, ?> fields) {
+        return this;
+    }
+
+    @Override
+    public NoopSpan log(long timestampMicroseconds, Map<String, ?> fields) {
+        return this;
+    }
+
+    @Override
+    public NoopSpan log(String event) {
+        return this;
+    }
+
+    @Override
+    public NoopSpan log(long timestampMicroseconds, String event) {
+        return this;
+    }
+
+    @Override
+    public NoopSpan setBaggageItem(String key, String value) {
+        return this;
+    }
+
+    @Override
+    public String getBaggageItem(String key) {
+        return null;
+    }
+
+    @Override
+    public NoopSpan setOperationName(String operationName) {
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return NoopSpan.class.getSimpleName();
+    }
+}

--- a/tracing-extensions/modules/ballerina-noop-extension/src/main/java/org/ballerinalang/observe/trace/extension/noop/NoopSpanBuilder.java
+++ b/tracing-extensions/modules/ballerina-noop-extension/src/main/java/org/ballerinalang/observe/trace/extension/noop/NoopSpanBuilder.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.observe.trace.extension.noop;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A no-op implementation of a SpanBuilder.
+ */
+public interface NoopSpanBuilder extends Tracer.SpanBuilder, NoopSpanContext {
+    NoopSpanBuilder INSTANCE = new NoopSpanBuilderImpl();
+}
+
+final class NoopSpanBuilderImpl implements NoopSpanBuilder {
+
+    @Override
+    public Tracer.SpanBuilder addReference(String refType, SpanContext referenced) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder asChildOf(SpanContext parent) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder ignoreActiveSpan() {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder asChildOf(Span parent) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withTag(String key, String value) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withTag(String key, boolean value) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withTag(String key, Number value) {
+        return this;
+    }
+
+    @Override
+    public Tracer.SpanBuilder withStartTimestamp(long microseconds) {
+        return this;
+    }
+
+    @Override
+    public Scope startActive(boolean finishOnClose) {
+        return NoopScopeManager.NoopScope.INSTANCE;
+    }
+
+    @Override
+    public Span start() {
+        return startManual();
+    }
+
+    @Override
+    public Span startManual() {
+        return NoopSpanImpl.INSTANCE;
+    }
+
+    @Override
+    public Iterable<Map.Entry<String, String>> baggageItems() {
+        return Collections.<String, String>emptyMap().entrySet();
+    }
+
+    @Override
+    public String toString() {
+        return NoopSpanBuilder.class.getSimpleName();
+    }
+}

--- a/tracing-extensions/modules/ballerina-noop-extension/src/main/java/org/ballerinalang/observe/trace/extension/noop/NoopSpanContext.java
+++ b/tracing-extensions/modules/ballerina-noop-extension/src/main/java/org/ballerinalang/observe/trace/extension/noop/NoopSpanContext.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.observe.trace.extension.noop;
+
+import io.opentracing.SpanContext;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A no-op implementation of a SpanContext.
+ */
+public interface NoopSpanContext extends SpanContext {
+}
+
+final class NoopSpanContextImpl implements NoopSpanContext {
+    static final NoopSpanContextImpl INSTANCE = new NoopSpanContextImpl();
+
+    @Override
+    public Iterable<Map.Entry<String, String>> baggageItems() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String toString() {
+        return NoopSpanContext.class.getSimpleName();
+    }
+}
+

--- a/tracing-extensions/modules/ballerina-noop-extension/src/main/java/org/ballerinalang/observe/trace/extension/noop/NoopTracer.java
+++ b/tracing-extensions/modules/ballerina-noop-extension/src/main/java/org/ballerinalang/observe/trace/extension/noop/NoopTracer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.observe.trace.extension.noop;
+
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.noop.NoopScopeManager;
+import io.opentracing.propagation.Format;
+
+/**
+ * A no-op implementation of a Tracer.
+ */
+public class NoopTracer implements Tracer {
+    public static final NoopTracer INSTANCE = new NoopTracer();
+
+    @Override
+    public ScopeManager scopeManager() {
+        return NoopScopeManager.INSTANCE;
+    }
+
+    @Override
+    public Span activeSpan() {
+        return NoopSpanImpl.INSTANCE;
+    }
+
+    @Override
+    public SpanBuilder buildSpan(String operationName) {
+        return NoopSpanBuilderImpl.INSTANCE;
+    }
+
+    @Override
+    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+    }
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C carrier) {
+        return NoopSpanBuilderImpl.INSTANCE;
+    }
+
+    @Override
+    public String toString() {
+        return NoopTracer.class.getSimpleName();
+    }
+}

--- a/tracing-extensions/modules/ballerina-noop-extension/src/main/java/org/ballerinalang/observe/trace/extension/noop/OpenTracingExtension.java
+++ b/tracing-extensions/modules/ballerina-noop-extension/src/main/java/org/ballerinalang/observe/trace/extension/noop/OpenTracingExtension.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.observe.trace.extension.noop;
+
+import io.opentracing.Tracer;
+import org.ballerinalang.util.tracer.OpenTracer;
+
+import java.util.Properties;
+
+/**
+ * Tracer extension that returns an instance of no-op tracer.
+ */
+public class OpenTracingExtension implements OpenTracer {
+    @Override
+    public Tracer getTracer(String tracerName, Properties configProperties, String serviceName) {
+        return NoopTracer.INSTANCE;
+    }
+}

--- a/tracing-extensions/pom.xml
+++ b/tracing-extensions/pom.xml
@@ -1,0 +1,42 @@
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.ballerinalang</groupId>
+        <artifactId>ballerina-observability-parent</artifactId>
+        <version>0.970.0-alpha1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>tracing-extensions</artifactId>
+    <packaging>pom</packaging>
+    <name>Ballerina - Tracing Extensions - Parent</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>modules/ballerina-jaeger-extension</module>
+    </modules>
+
+</project>

--- a/tracing-extensions/pom.xml
+++ b/tracing-extensions/pom.xml
@@ -37,6 +37,7 @@
 
     <modules>
         <module>modules/ballerina-jaeger-extension</module>
+        <module>modules/ballerina-noop-extension</module>
     </modules>
 
 </project>


### PR DESCRIPTION
## Purpose
- Move observability extension from ballerina-lang to ballerina-observability.
- Add Jaeger tracing extension.
- Add no-op tracing extension.
- Add placeholders for metrics extensions.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no
