### PR TITLE
Remove maven-dependency-plugin and fixed extension distributions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,16 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven.assembly.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-remote-resources-plugin</artifactId>
+                <version>${maven.remote.resource.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>${maven.deploy.plugin.version}</version>
             </plugin>
@@ -376,11 +386,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-remote-resources-plugin</artifactId>
-                <version>${maven.remote.resource.plugin.version}</version>
-            </plugin>
         </plugins>
     </build>
 
@@ -389,6 +394,7 @@
         <project.scm.id>my-scm-server</project.scm.id>
         <maven.wagon.ssh.version>2.1</maven.wagon.ssh.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
+        <maven.assembly.plugin.version>2.6</maven.assembly.plugin.version>
         <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
         <wso2.maven.compiler.source>1.8</wso2.maven.compiler.source>
         <wso2.maven.compiler.target>1.8</wso2.maven.compiler.target>

--- a/tracing-extensions/modules/ballerina-jaeger-extension/pom.xml
+++ b/tracing-extensions/modules/ballerina-jaeger-extension/pom.xml
@@ -66,78 +66,18 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>${maven.dependency.plugin.version}</version>
-                <inherited>false</inherited>
-                <executions>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>${project.artifactId}</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.uber.jaeger</groupId>
-                                    <artifactId>jaeger-core</artifactId>
-                                    <version>${jaeger.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.uber.jaeger</groupId>
-                                    <artifactId>jaeger-thrift</artifactId>
-                                    <version>${jaeger.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.thrift</groupId>
-                                    <artifactId>libthrift</artifactId>
-                                    <version>${libthrift.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.squareup.okhttp3</groupId>
-                                    <artifactId>okhttp</artifactId>
-                                    <version>${okhttp.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.squareup.okio</groupId>
-                                    <artifactId>okio</artifactId>
-                                    <version>${okio.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                            </artifactItems>
-                            <outputDirectory>${project.build.directory}/jaeger-extension</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>true</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                            <useBaseVersion>true</useBaseVersion>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptors>
                         <descriptor>src/main/assembly/dist.xml</descriptor>
                     </descriptors>
-                    <finalName>jaeger-extension</finalName>
+                    <finalName>distribution</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                 </configuration>
                 <executions>
                     <execution>
                         <id>make-assembly</id>
-                        <phase>install</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>

--- a/tracing-extensions/modules/ballerina-jaeger-extension/src/main/assembly/dist.xml
+++ b/tracing-extensions/modules/ballerina-jaeger-extension/src/main/assembly/dist.xml
@@ -19,15 +19,24 @@
 <assembly xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
-    <id>bin</id>
+    <id>distribution</id>
     <includeBaseDirectory>false</includeBaseDirectory>
     <formats>
         <format>zip</format>
     </formats>
-    <fileSets>
-        <fileSet>
-            <directory>${project.build.directory}/jaeger-extension</directory>
-            <outputDirectory>jaeger-extension</outputDirectory>
-        </fileSet>
-    </fileSets>
+
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory></outputDirectory>
+            <scope>runtime</scope>
+            <includes>
+                <include>org.ballerinalang:ballerina-jaeger-extension:jar</include>
+                <include>com.uber.jaeger:jaeger-core</include>
+                <include>com.uber.jaeger:jaeger-thrift</include>
+                <include>org.apache.thrift:libthrift</include>
+                <include>com.squareup.okhttp3:okhttp</include>
+                <include>com.squareup.okio:okio</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
 </assembly>

--- a/tracing-extensions/modules/ballerina-noop-extension/pom.xml
+++ b/tracing-extensions/modules/ballerina-noop-extension/pom.xml
@@ -46,48 +46,18 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>${maven.dependency.plugin.version}</version>
-                <inherited>false</inherited>
-                <executions>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>${project.artifactId}</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                            </artifactItems>
-                            <outputDirectory>${project.build.directory}/noop-extension</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>true</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                            <useBaseVersion>true</useBaseVersion>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptors>
                         <descriptor>src/main/assembly/dist.xml</descriptor>
                     </descriptors>
-                    <finalName>noop-extension</finalName>
+                    <finalName>distribution</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                 </configuration>
                 <executions>
                     <execution>
                         <id>make-assembly</id>
-                        <phase>install</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>

--- a/tracing-extensions/modules/ballerina-noop-extension/src/main/assembly/dist.xml
+++ b/tracing-extensions/modules/ballerina-noop-extension/src/main/assembly/dist.xml
@@ -19,15 +19,20 @@
 <assembly xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
-    <id>bin</id>
+    <id>distribution</id>
     <includeBaseDirectory>false</includeBaseDirectory>
     <formats>
         <format>zip</format>
     </formats>
-    <fileSets>
-        <fileSet>
-            <directory>${project.build.directory}/noop-extension</directory>
-            <outputDirectory>noop-extension</outputDirectory>
-        </fileSet>
-    </fileSets>
+
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory></outputDirectory>
+            <scope>runtime</scope>
+            <includes>
+                <include>org.ballerinalang:ballerina-noop-extension:jar</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+
 </assembly>

--- a/tracing-extensions/modules/ballerina-zipkin-extension/README.md
+++ b/tracing-extensions/modules/ballerina-zipkin-extension/README.md
@@ -3,7 +3,7 @@
 ##### Install Guide
 
 - Start Zipkin. You can use their docker image using following command. `docker run -d -p 9411:9411 openzipkin/zipkin`.
-- Build `ballerina-zipkin-extension` and copy the jar files found in <ballerina-zipkin-extension>/target/zipkin-extension/
+- Build `ballerina-zipkin-extension` and copy the jar files found in <ballerina-zipkin-extension>/target/distribution/
  into the `bre/lib/` directory of the ballerina distribution.
 
 - Create a `trace-config.yaml` with following properties.

--- a/tracing-extensions/modules/ballerina-zipkin-extension/pom.xml
+++ b/tracing-extensions/modules/ballerina-zipkin-extension/pom.xml
@@ -58,78 +58,18 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>${maven.dependency.plugin.version}</version>
-                <inherited>false</inherited>
-                <executions>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>${project.artifactId}</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.opentracing.brave</groupId>
-                                    <artifactId>brave-opentracing</artifactId>
-                                    <version>${brave.open.tracing.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.zipkin.brave</groupId>
-                                    <artifactId>brave</artifactId>
-                                    <version>${brave.zipkin.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.zipkin.reporter2</groupId>
-                                    <artifactId>zipkin-reporter</artifactId>
-                                    <version>${zipkin.reporter.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.zipkin.zipkin2</groupId>
-                                    <artifactId>zipkin</artifactId>
-                                    <version>${zipkin.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>io.zipkin.reporter2</groupId>
-                                    <artifactId>zipkin-sender-okhttp3</artifactId>
-                                    <version>${zipkin.reporter.version}</version>
-                                    <type>${project.packaging}</type>
-                                </artifactItem>
-                            </artifactItems>
-                            <outputDirectory>${project.build.directory}/zipkin-extension</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>true</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                            <useBaseVersion>true</useBaseVersion>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptors>
                         <descriptor>src/main/assembly/dist.xml</descriptor>
                     </descriptors>
-                    <finalName>zipkin-extension</finalName>
+                    <finalName>distribution</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                 </configuration>
                 <executions>
                     <execution>
                         <id>make-assembly</id>
-                        <phase>install</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>

--- a/tracing-extensions/modules/ballerina-zipkin-extension/src/main/assembly/dist.xml
+++ b/tracing-extensions/modules/ballerina-zipkin-extension/src/main/assembly/dist.xml
@@ -19,15 +19,25 @@
 <assembly xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
-    <id>bin</id>
+    <id>distribution</id>
     <includeBaseDirectory>false</includeBaseDirectory>
     <formats>
         <format>zip</format>
     </formats>
-    <fileSets>
-        <fileSet>
-            <directory>${project.build.directory}/zipkin-extension</directory>
-            <outputDirectory>zipkin-extension</outputDirectory>
-        </fileSet>
-    </fileSets>
+
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory></outputDirectory>
+            <scope>runtime</scope>
+            <includes>
+                <include>org.ballerinalang:ballerina-zipkin-extension:jar</include>
+                <include>io.opentracing.brave:brave-opentracing</include>
+                <include>io.zipkin.brave:brave</include>
+                <include>io.zipkin.reporter2:zipkin-reporter</include>
+                <include>io.zipkin.zipkin2:zipkin</include>
+                <include>io.zipkin.reporter2:zipkin-sender-okhttp3</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+
 </assembly>

--- a/tracing-extensions/modules/ballerina-zipkin-extension/src/main/java/org/ballerinalang/observe/trace/extension/zipkin/OpenTracingExtension.java
+++ b/tracing-extensions/modules/ballerina-zipkin-extension/src/main/java/org/ballerinalang/observe/trace/extension/zipkin/OpenTracingExtension.java
@@ -17,20 +17,20 @@
  */
 package org.ballerinalang.observe.trace.extension.zipkin;
 
+import brave.Tracing;
+import brave.opentracing.BraveTracer;
 import io.opentracing.Tracer;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.util.tracer.OpenTracer;
 import org.ballerinalang.util.tracer.exception.InvalidConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Properties;
-
-import brave.Tracing;
-import brave.opentracing.BraveTracer;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.okhttp3.OkHttpSender;
+
+import java.util.Properties;
+
 import static org.ballerinalang.observe.trace.extension.zipkin.Constants.DEFAULT_REPORTER_HOSTNAME;
 import static org.ballerinalang.observe.trace.extension.zipkin.Constants.DEFAULT_REPORTER_PORT;
 import static org.ballerinalang.observe.trace.extension.zipkin.Constants.REPORTER_HOST_NAME_CONFIG;


### PR DESCRIPTION
## Purpose
Purpose of this PR is to remove maven-dependency-plugin and fixed extension distributions. So that it will create separate `.zip` files which can be used when building ballerina distribution.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no
