### PR TITLE
Review and update incorrect queries in grafana dashboard

### DIFF
--- a/metrics-extensions/modules/grafana-dashboards/dashboards/ballerina-metrics-grafana-dashboard-prometheus.json
+++ b/metrics-extensions/modules/grafana-dashboards/dashboards/ballerina-metrics-grafana-dashboard-prometheus.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
+      "name": "DS_PROMETHEUSDS",
+      "label": "PrometheusDS",
       "description": "",
       "type": "datasource",
       "pluginId": "prometheus",
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1524648716975,
+  "iteration": 1524808799686,
   "links": [],
   "panels": [
     {
@@ -60,7 +60,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "decimals": 0,
       "fill": 3,
       "gridPos": {
@@ -173,7 +173,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -225,7 +225,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(http_requests_total[1m]))",
+          "expr": "\nsum(max_over_time(http_requests_total{instance=~\"$instance\",protocol=~\"$protocol\",http_method=~\"$http_method\",http_url=~\"$http_url\",service=~\"$service\",resource=~\"$resource\"}[1m])-min_over_time(http_requests_total{instance=~\"$instance\",protocol=~\"$protocol\",http_method=~\"$http_method\",http_url=~\"$http_url\",service=~\"$service\",resource=~\"$resource\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -254,7 +254,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -306,7 +306,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(ballerina_http:Connection_4XX_requests_total[1m])+rate(ballerina_http:Connection_5XX_requests_total[1m]))",
+          "expr": "sum(max_over_time(ballerina_http:Connection_4XX_requests_total{instance=~\"$instance\"}[1m])-min_over_time(ballerina_http:Connection_4XX_requests_total{instance=~\"$instance\"}[1m])+max_over_time(ballerina_http:Connection_5XX_requests_total{instance=~\"$instance\"}[1m])-min_over_time(ballerina_http:Connection_5XX_requests_total{instance=~\"$instance\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -335,7 +335,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "decimals": null,
       "format": "none",
       "gauge": {
@@ -388,7 +388,7 @@
       "tableColumn": "__name__",
       "targets": [
         {
-          "expr": "sum(http_inprogress_requests)",
+          "expr": "sum(http_inprogress_requests{instance=~\"$instance\",service=~\"$service\",resource=~\"$resource\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -417,7 +417,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -469,7 +469,7 @@
       "tableColumn": "Value",
       "targets": [
         {
-          "expr": "sum(increase(ballerina_http:Connection_4XX_requests_total[1m])+increase(ballerina_http:Connection_5XX_requests_total[1m]))*100/sum(increase(ballerina_http:Connection_requests_total[1m]))",
+          "expr": "sum(max_over_time(ballerina_http:Connection_4XX_requests_total{instance=~\"$instance\"}[1m]) - min_over_time(ballerina_http:Connection_4XX_requests_total{instance=~\"$instance\"}[1m])+max_over_time(ballerina_http:Connection_5XX_requests_total{instance=~\"$instance\"}[1m]) - min_over_time(ballerina_http:Connection_5XX_requests_total{instance=~\"$instance\"}[1m]))*100/sum(max_over_time(ballerina_http:Connection_requests_total{instance=~\"$instance\"}[1m]) - min_over_time(ballerina_http:Connection_requests_total{instance=~\"$instance\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -496,7 +496,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "description": "",
       "fill": 1,
       "gridPos": {
@@ -531,7 +531,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(http_requests_total{instance=~\"$instance\",protocol=~\"$protocol\",http_method=~\"$http_method\",http_url=~\"$http_url\",service=~\"$service\",resource=~\"$resource\"}[1m])",
+          "expr": "sum without (http_status_code)(rate(http_requests_total{instance=~\"$instance\",protocol=~\"$protocol\",http_method=~\"$http_method\",http_url=~\"$http_url\",service=~\"$service\",resource=~\"$resource\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -562,7 +562,7 @@
         {
           "decimals": null,
           "format": "ops",
-          "label": "Requests / min",
+          "label": "Requests / sec",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -583,7 +583,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "description": "",
       "fill": 1,
       "gridPos": {
@@ -673,7 +673,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -705,14 +705,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(ballerina_http:Connection_1XX_requests_total{instance=~\"$instance\",action=\"respond\"}[1m])",
+          "expr": "rate(ballerina_http:Connection_1XX_requests_total{instance=~\"$instance\", action=~\"respond\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "1xx Informational responses - Instance: {{instance}}",
           "refId": "A"
         },
         {
-          "expr": "rate(ballerina_http:Connection_2XX_requests_total{instance=~\"$instance\",action=\"respond\"}[1m])",
+          "expr": "rate(ballerina_http:Connection_2XX_requests_total{instance=~\"$instance\", action=~\"respond\"}[1m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -720,21 +720,21 @@
           "refId": "B"
         },
         {
-          "expr": "rate(ballerina_http:Connection_3XX_requests_total{instance=~\"$instance\",action=\"respond\"}[1m])  ",
+          "expr": "rate(ballerina_http:Connection_3XX_requests_total{instance=~\"$instance\", action=~\"respond\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "3xx Redirections - Instance: {{instance}}",
           "refId": "C"
         },
         {
-          "expr": "rate(ballerina_http:Connection_4XX_requests_total{instance=~\"$instance\",action=\"respond\"}[1m])",
+          "expr": "rate(ballerina_http:Connection_4XX_requests_total{instance=~\"$instance\", action=~\"respond\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "4xx Client errors - Instance: {{instance}}",
           "refId": "D"
         },
         {
-          "expr": "rate(ballerina_http:Connection_5XX_requests_total{instance=~\"$instance\",action=\"respond\"}[1m])",
+          "expr": "rate(ballerina_http:Connection_5XX_requests_total{instance=~\"$instance\", action=~\"respond\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "5xx Server errors - Instance: {{instance}}",
@@ -761,7 +761,7 @@
       "yaxes": [
         {
           "format": "short",
-          "label": "Requests / min",
+          "label": "Requests / sec",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -782,7 +782,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -883,7 +883,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -935,7 +935,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(ballerina_http:HttpCachingClient_requests_total[1m]))",
+          "expr": "sum( max_over_time({__name__=~\".*.:.*.Client_requests_total\", instance=~\"$instance\", peer_address=~\"$peer_address\", action=~\"$http_client_action\"}[1m]) - min_over_time({__name__=~\".*.:.*.Client_requests_total\", instance=~\"$instance\", peer_address=~\"$peer_address\", action=~\"$http_client_action\"}[1m]) ) ",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -964,7 +964,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -1016,7 +1016,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(ballerina_http:HttpCachingClient_4XX_requests_total[1m])+rate(ballerina_http:HttpCachingClient_5XX_requests_total[1m]))",
+          "expr": "sum( max_over_time({__name__=~\".*.:.*.Client_4XX_requests_total\", instance=~\"$instance\", action=~\"$http-client-action\"}[1m]) - min_over_time({__name__=~\".*.:.*.Client_4XX_requests_total\", instance=~\"$instance\", peer_address=~\"$peer_address\", action=~\"$http-client-action\"}[1m])+ max_over_time({__name__=~\".*.:.*.Client_5XX_requests_total\", instance=~\"$instance\", peer_address=~\"$peer_address\", action=~\"$http-client-action\"}[1m]) - min_over_time({__name__=~\".*.:.*.Client_5XX_requests_total\", instance=~\"$instance\", action=~\"$http-client-action\"}[1m]) )",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1045,7 +1045,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "decimals": null,
       "format": "none",
       "gauge": {
@@ -1098,7 +1098,7 @@
       "tableColumn": "__name__",
       "targets": [
         {
-          "expr": "sum(ballerina_http:HttpCachingClient_inprogress_requests)",
+          "expr": "sum({__name__=~\".*.:.*.Client_inprogress_requests\", action=~\"$http_client_action\", instance=~\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -1127,7 +1127,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -1179,7 +1179,7 @@
       "tableColumn": "Value",
       "targets": [
         {
-          "expr": "sum(increase(ballerina_http:HttpCachingClient_4XX_requests_total[1m])+increase(ballerina_http:HttpCachingClient_5XX_requests_total[1m]))*100/sum(increase(ballerina_http:HttpCachingClient_requests_total[1m]))",
+          "expr": "sum( max_over_time({__name__=~\".*.:.*.Client_4XX_requests_total\", instance=~\"$instance\", action=~\"$http-client-action\"}[1m]) - min_over_time({__name__=~\".*.:.*.Client_4XX_requests_total\", instance=~\"$instance\", peer_address=~\"$peer_address\", action=~\"$http-client-action\"}[1m])+ max_over_time({__name__=~\".*.:.*.Client_5XX_requests_total\", instance=~\"$instance\", peer_address=~\"$peer_address\", action=~\"$http-client-action\"}[1m]) - min_over_time({__name__=~\".*.:.*.Client_5XX_requests_total\", instance=~\"$instance\", action=~\"$http-client-action\"}[1m]))*100/sum( max_over_time({__name__=~\".*.:.*.Client_requests_total\", instance=~\"$instance\", action=~\"$http-client-action\"}[1m]) - min_over_time({__name__=~\".*.:.*.Client_requests_total\", instance=~\"$instance\", peer_address=~\"$peer_address\", action=~\"$http-client-action\"}[1m]))\n",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1206,7 +1206,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "description": "",
       "fill": 1,
       "gridPos": {
@@ -1240,7 +1240,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum without(http_status_code)(rate(ballerina_http:HttpCachingClient_requests_total{instance=~\"$instance\",action=~\"$http_client_action\",http_method=~\"$http_method\",peer_address=~\"$peer_address\",http_url=~\"$http_url\"}[1m]))",
+          "expr": "sum (rate({__name__=~\".*.:.*.Client_requests_total\", instance=~\"$instance\",action=~\"$http_client_action\",http_method=~\"$http_method\",peer_address=~\"$peer_address\",http_url=~\"$http_url\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1268,7 +1268,7 @@
       "yaxes": [
         {
           "format": "ops",
-          "label": "Requests / min",
+          "label": "Requests / sec",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -1289,7 +1289,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "description": "",
       "fill": 1,
       "gridPos": {
@@ -1323,7 +1323,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum without(http_status_code)(ballerina_http:HttpCachingClient_response_time_seconds{instance=~\"$instance\",action=~\"$http_client_action\",http_method=~\"$http_method\",peer_address=~\"$peer_address\",http_url=~\"$http_url\"})",
+          "expr": "sum without(http_status_code) ({__name__=~\".*.:.*.Client_response_time_seconds\", instance=~\"$instance\",action=~\"$http_client_action\",http_method=~\"$http_method\",peer_address=~\"$peer_address\",http_url=~\"$http_url\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1380,7 +1380,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1412,14 +1412,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(ballerina_http:HttpCachingClient_1XX_requests_total{instance=~\"$instance\",action=~\"$http_client_action\"}[1m])",
+          "expr": "rate({__name__=~\".*.:.*.Client_1XX_requests_total\", instance=~\"$instance\", action=~\"$http_client_action\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "1xx Informational responses - Instance: {{instance}}, Action: {{action}}",
           "refId": "A"
         },
         {
-          "expr": "rate(ballerina_http:HttpCachingClient_2XX_requests_total{instance=~\"$instance\",action=~\"$http_client_action\"}[1m])",
+          "expr": "rate({__name__=~\".*.:.*.Client_2XX_requests_total\", instance=~\"$instance\", action=~\"$http_client_action\"}[1m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1427,21 +1427,21 @@
           "refId": "B"
         },
         {
-          "expr": "rate(ballerina_http:HttpCachingClient_3XX_requests_total{instance=~\"$instance\",action=~\"$http_client_action\"}[1m])",
+          "expr": "rate({__name__=~\".*.:.*.Client_3XX_requests_total\", instance=~\"$instance\", action=~\"$http_client_action\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "3xx Redirections - Instance: {{instance}}, Action: {{action}}",
           "refId": "C"
         },
         {
-          "expr": "rate(ballerina_http:HttpCachingClient_4XX_requests_total{instance=~\"$instance\",action=~\"$http_client_action\"}[1m])",
+          "expr": "rate({__name__=~\".*.:.*.Client_4XX_requests_total\", instance=~\"$instance\", action=~\"$http_client_action\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "4xx Client errors - Instance: {{instance}}, Action: {{action}}",
           "refId": "D"
         },
         {
-          "expr": "rate(ballerina_http:HttpCachingClient_5XX_requests_total{instance=~\"$instance\",action=~\"$http_client_action\"}[1m])",
+          "expr": "rate({__name__=~\".*.:.*.Client_5XX_requests_total\", instance=~\"$instance\", action=~\"$http_client_action\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "5xx Server errors - Instance: {{instance}}, Action: {{action}}",
@@ -1468,7 +1468,7 @@
       "yaxes": [
         {
           "format": "short",
-          "label": "Requests / min",
+          "label": "Requests / sec",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -1489,7 +1489,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -1590,7 +1590,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -1642,7 +1642,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(ballerina_sql:CallerActions_requests_total[1m]))",
+          "expr": "sum(max_over_time(ballerina_sql:CallerActions_requests_total{instance=~\"$instance\",action=~\"$db_action\",peer_address=~\"$peer_address\",db_instance=~\"$db_instance\",db_statement=~\"$db_statement\"}[1m])-min_over_time(ballerina_sql:CallerActions_requests_total{instance=~\"$instance\",action=~\"$db_action\",peer_address=~\"$peer_address\",db_instance=~\"$db_instance\",db_statement=~\"$db_statement\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1650,7 +1650,7 @@
         }
       ],
       "thresholds": "",
-      "title": "Statements / min",
+      "title": "Executions / min",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -1671,7 +1671,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -1723,7 +1723,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(ballerina_sql:CallerActions_failed_requests_total[1m]))",
+          "expr": "sum (max_over_time(ballerina_sql:CallerActions_failed_requests_total{instance=~\"$instance\",action=~\"$db_action\",peer_address=~\"$peer_address\",db_instance=~\"$db_instance\",db_statement=~\"$db_statement\"}[1m]) - min_over_time(ballerina_sql:CallerActions_failed_requests_total{instance=~\"$instance\",action=~\"$db_action\",peer_address=~\"$peer_address\",db_instance=~\"$db_instance\",db_statement=~\"$db_statement\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1752,7 +1752,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "decimals": null,
       "format": "none",
       "gauge": {
@@ -1805,7 +1805,7 @@
       "tableColumn": "__name__",
       "targets": [
         {
-          "expr": "sum(ballerina_sql:CallerActions_inprogress_requests)",
+          "expr": "sum(ballerina_sql:CallerActions_inprogress_requests{action=~\"$db_action\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -1834,7 +1834,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -1886,7 +1886,7 @@
       "tableColumn": "Value",
       "targets": [
         {
-          "expr": "sum(increase(ballerina_sql:CallerActions_failed_requests_total[1m]))*100/sum(increase(ballerina_sql:CallerActions_requests_total[1m]))",
+          "expr": "sum (max_over_time(ballerina_sql:CallerActions_failed_requests_total{instance=~\"$instance\",action=~\"$db_action\",peer_address=~\"$peer_address\",db_instance=~\"$db_instance\",db_statement=~\"$db_statement\"}[1m]) - min_over_time(ballerina_sql:CallerActions_failed_requests_total{instance=~\"$instance\",action=~\"$db_action\",peer_address=~\"$peer_address\",db_instance=~\"$db_instance\",db_statement=~\"$db_statement\"}[1m]))*100/sum(max_over_time(ballerina_sql:CallerActions_requests_total{instance=~\"$instance\",action=~\"$db_action\",peer_address=~\"$peer_address\",db_instance=~\"$db_instance\",db_statement=~\"$db_statement\"}[1m]) - min_over_time(ballerina_sql:CallerActions_requests_total{instance=~\"$instance\",action=~\"$db_action\",peer_address=~\"$peer_address\",db_instance=~\"$db_instance\",db_statement=~\"$db_statement\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1913,7 +1913,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "description": "",
       "fill": 1,
       "gridPos": {
@@ -1976,7 +1976,7 @@
       "yaxes": [
         {
           "format": "ops",
-          "label": "Statements / min",
+          "label": "Statements / sec",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -1997,7 +1997,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "description": "",
       "fill": 1,
       "gridPos": {
@@ -2079,7 +2079,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "description": "",
       "fill": 1,
       "gridPos": {
@@ -2142,7 +2142,7 @@
       "yaxes": [
         {
           "format": "ops",
-          "label": "Statements / min",
+          "label": "Statements / sec",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -2163,7 +2163,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -2260,7 +2260,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "${DS_PROMETHEUSDS}",
       "description": "Scheduler Metrics should be enabled in Ballerina",
       "fill": 1,
       "gridPos": {
@@ -2393,7 +2393,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "${DS_PROMETHEUSDS}",
         "hide": 0,
         "includeAll": true,
         "label": "instance",
@@ -2413,7 +2413,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "${DS_PROMETHEUSDS}",
         "hide": 0,
         "includeAll": true,
         "label": "service",
@@ -2433,7 +2433,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "${DS_PROMETHEUSDS}",
         "hide": 0,
         "includeAll": true,
         "label": "resource",
@@ -2453,7 +2453,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "${DS_PROMETHEUSDS}",
         "hide": 0,
         "includeAll": true,
         "label": "protocol",
@@ -2473,7 +2473,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "${DS_PROMETHEUSDS}",
         "hide": 0,
         "includeAll": true,
         "label": "http-method",
@@ -2493,7 +2493,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "${DS_PROMETHEUSDS}",
         "hide": 0,
         "includeAll": true,
         "label": "http-url",
@@ -2513,7 +2513,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "${DS_PROMETHEUSDS}",
         "hide": 0,
         "includeAll": true,
         "label": "peer-address",
@@ -2533,7 +2533,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "${DS_PROMETHEUSDS}",
         "hide": 0,
         "includeAll": true,
         "label": "http-client-action",
@@ -2553,7 +2553,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "${DS_PROMETHEUSDS}",
         "hide": 0,
         "includeAll": true,
         "label": "db-action",
@@ -2573,7 +2573,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "${DS_PROMETHEUSDS}",
         "hide": 0,
         "includeAll": true,
         "label": "db-statement",
@@ -2593,7 +2593,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "${DS_PROMETHEUSDS}",
         "hide": 0,
         "includeAll": true,
         "label": "db-instance",
@@ -2644,5 +2644,5 @@
   "timezone": "",
   "title": "Ballerina Metrics",
   "uid": "8FPN-nmik",
-  "version": 37
+  "version": 1
 }


### PR DESCRIPTION
## Purpose
Grafana dashboard visualizes the metrics data and uses queries to fetch the data from prometheus. Some queries were not appropriately used for the data that's getting visualized, and hence the accuracy of the data is compromised. This PR involves in revising the queries and correcting it when needed.

## Goals
Fix the incorrect queries used.

## Approach
Went through each and every query used in the dashboard with Prometheus official guide, and fixed it.