### PR TITLE
Support Zipkin V1 APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,11 @@
             </dependency>
             <dependency>
                 <groupId>io.zipkin.reporter2</groupId>
+                <artifactId>zipkin-sender-urlconnection</artifactId>
+                <version>${zipkin.reporter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.zipkin.reporter2</groupId>
                 <artifactId>zipkin-sender-okhttp3</artifactId>
                 <version>${zipkin.reporter.version}</version>
             </dependency>

--- a/tracing-extensions/modules/ballerina-zipkin-extension/pom.xml
+++ b/tracing-extensions/modules/ballerina-zipkin-extension/pom.xml
@@ -49,6 +49,10 @@
         </dependency>
         <dependency>
             <groupId>io.zipkin.reporter2</groupId>
+            <artifactId>zipkin-sender-urlconnection</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.reporter2</groupId>
             <artifactId>zipkin-sender-okhttp3</artifactId>
         </dependency>
     </dependencies>

--- a/tracing-extensions/modules/ballerina-zipkin-extension/src/main/assembly/dist.xml
+++ b/tracing-extensions/modules/ballerina-zipkin-extension/src/main/assembly/dist.xml
@@ -33,6 +33,7 @@
                 <include>io.zipkin.reporter2:zipkin-reporter</include>
                 <include>io.zipkin.zipkin2:zipkin</include>
                 <include>io.zipkin.reporter2:zipkin-sender-okhttp3</include>
+                <include>io.zipkin.reporter2:zipkin-sender-urlconnection</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/tracing-extensions/modules/ballerina-zipkin-extension/src/main/java/org/ballerinalang/observe/trace/extension/zipkin/Constants.java
+++ b/tracing-extensions/modules/ballerina-zipkin-extension/src/main/java/org/ballerinalang/observe/trace/extension/zipkin/Constants.java
@@ -24,14 +24,18 @@ package org.ballerinalang.observe.trace.extension.zipkin;
  * that are used by the {@link OpenTracingExtension}.
  */
 public class Constants {
-    static final String TRACER_NAME = "zipkin";
 
-    static final String REPORTING_API_CONTEXT = "/api/v2/spans";
     static final String REPORTER_HOST_NAME_CONFIG = "reporter.hostname";
     static final String REPORTER_PORT_CONFIG = "reporter.port";
+    static final String REPORTER_API_CONTEXT_CONFIG = "reporter.api.context";
+    static final String REPORTER_COMPRESSION_ENABLED_CONFIG = "reporter.compression.enabled";
+    static final String REPORTER_API_VERSION = "reporter.api.version";
 
+    static final String DEFAULT_REPORTER_API_CONTEXT = "/api/v2/spans";
     static final String DEFAULT_REPORTER_HOSTNAME = "localhost";
     static final int DEFAULT_REPORTER_PORT = 9411;
+    static final boolean DEFAULT_REPORTER_COMPRESSION_ENABLED = true;
+    static final String DEFAULT_REPORTER_API_VERSION = "v2";
 
     private Constants() {
 


### PR DESCRIPTION
## Purpose
Zipkin have v1 and v2 APIs supported. The older version of zipkin only support V1. And the monitoring service provider like [honeycomb zipkin proxy](https://docs.honeycomb.io/working-with-data/tracing/send-trace-data/#opentracing)  supports only V1. Therefore, it's essential to support V1 and V2 APIs

## Goals
The properties to initialize the clients for V1 and V2 apis are added as configurations of zipkin tracer.
