### PR TITLE
Add WSO2 Stream Processor Open tracing extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,41 @@
                 <version>${zipkin.reporter.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.sp</groupId>
+                <artifactId>org.wso2.sp.open.tracer.client</artifactId>
+                <version>${wso2sp.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.analytics-common</groupId>
+                <artifactId>org.wso2.carbon.databridge.agent</artifactId>
+                <version>${carbon.analytics-common.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.analytics-common</groupId>
+                <artifactId>org.wso2.carbon.databridge.commons</artifactId>
+                <version>${carbon.analytics-common.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.log4j.wso2</groupId>
+                <artifactId>log4j</artifactId>
+                <version>${wso2.log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.config</groupId>
+                <artifactId>org.wso2.carbon.config</artifactId>
+                <version>${carbon.config.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.secvault</groupId>
+                <artifactId>org.wso2.carbon.secvault</artifactId>
+                <version>${carbon.securevault.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.analytics-common</groupId>
+                <artifactId>org.wso2.carbon.databridge.commons.thrift</artifactId>
+                <version>${carbon.analytics-common.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <version>${testng.version}</version>
@@ -540,6 +575,11 @@
         <brave.zipkin.version>4.17.1</brave.zipkin.version>
         <zipkin.reporter.version>2.5.0</zipkin.reporter.version>
         <zipkin.version>2.6.1</zipkin.version>
+        <wso2sp.version>4.3.0-SNAPSHOT</wso2sp.version>
+        <carbon.analytics-common.version>6.0.64</carbon.analytics-common.version>
+        <wso2.log4j.version>1.2.17.wso2v1</wso2.log4j.version>
+        <carbon.config.version>2.1.5</carbon.config.version>
+        <carbon.securevault.version>5.0.10</carbon.securevault.version>
     </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -580,7 +580,7 @@
         <brave.zipkin.version>4.17.1</brave.zipkin.version>
         <zipkin.reporter.version>2.5.0</zipkin.reporter.version>
         <zipkin.version>2.6.1</zipkin.version>
-        <wso2sp.version>4.3.0-M1</wso2sp.version>
+        <wso2sp.version>4.3.0-SNAPSHOT</wso2sp.version>
         <carbon.analytics-common.version>6.0.64</carbon.analytics-common.version>
         <org.wso2.json.version>3.0.0.wso2v1</org.wso2.json.version>
         <wso2.log4j.version>1.2.17.wso2v1</wso2.log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,11 @@
                 <version>${carbon.analytics-common.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.json.wso2</groupId>
+                <artifactId>json</artifactId>
+                <version>${org.wso2.json.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <version>${testng.version}</version>
@@ -575,8 +580,9 @@
         <brave.zipkin.version>4.17.1</brave.zipkin.version>
         <zipkin.reporter.version>2.5.0</zipkin.reporter.version>
         <zipkin.version>2.6.1</zipkin.version>
-        <wso2sp.version>4.3.0-SNAPSHOT</wso2sp.version>
+        <wso2sp.version>4.3.0-M1</wso2sp.version>
         <carbon.analytics-common.version>6.0.64</carbon.analytics-common.version>
+        <org.wso2.json.version>3.0.0.wso2v1</org.wso2.json.version>
         <wso2.log4j.version>1.2.17.wso2v1</wso2.log4j.version>
         <carbon.config.version>2.1.5</carbon.config.version>
         <carbon.securevault.version>5.0.10</carbon.securevault.version>

--- a/pom.xml
+++ b/pom.xml
@@ -257,9 +257,9 @@
                 <version>${zipkin.reporter.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.sp</groupId>
+                <groupId>org.wso2.carbon.analytics</groupId>
                 <artifactId>org.wso2.sp.open.tracer.client</artifactId>
-                <version>${wso2sp.version}</version>
+                <version>${carbon.analytics.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.analytics-common</groupId>
@@ -580,7 +580,7 @@
         <brave.zipkin.version>4.17.1</brave.zipkin.version>
         <zipkin.reporter.version>2.5.0</zipkin.reporter.version>
         <zipkin.version>2.6.1</zipkin.version>
-        <wso2sp.version>4.3.0-SNAPSHOT</wso2sp.version>
+        <carbon.analytics.version>2.0.395</carbon.analytics.version>
         <carbon.analytics-common.version>6.0.64</carbon.analytics-common.version>
         <org.wso2.json.version>3.0.0.wso2v1</org.wso2.json.version>
         <wso2.log4j.version>1.2.17.wso2v1</wso2.log4j.version>

--- a/tracing-extensions/modules/ballerina-jaeger-extension/README.md
+++ b/tracing-extensions/modules/ballerina-jaeger-extension/README.md
@@ -25,5 +25,5 @@ reporter.max.buffer.spans=1000
 
 - Run your Ballerina service with that `ballerina.conf` file.
   - Either place `ballerina.conf` in your applications directory.
-  - Or use `-Bballerina.conf=path/to/ballerina.conf`
+  - Or use `--config path/to/ballerina.conf`
 - Once everything is up and running, you can use jaeger dashboard to view traces.

--- a/tracing-extensions/modules/ballerina-sp-extension/README.md
+++ b/tracing-extensions/modules/ballerina-sp-extension/README.md
@@ -1,0 +1,29 @@
+### Ballerina WSO2 Stream Processor Extension
+
+##### Install Guide
+
+- Start WSO2 Stream processor dashboard runtime. And [setup the Distributed Message Tracing](https://docs.wso2.com/display/SP420/Distributed+Message+Tracer).
+- Build `ballerina-sp-extension` and copy the jar files found in `<ballerina-sp-extension>/target/distribution/`
+ into the `bre/lib/` directory of the ballerina distribution.
+
+- Create a `ballerina.conf` file with following properties.
+```toml
+[b7a.observability.tracing]
+enabled=true
+name="wso2sp"
+
+[b7a.observability.tracing.wso2sp]
+reporter.wso2sp.publisher.type="thrift"
+reporter.wso2sp.publisher.username="admin"
+reporter.wso2sp.publisher.password="admin"
+reporter.wso2sp.publisher.url="tcp://localhost:7611"
+reporter.wso2sp.publisher.authUrl="ssl://localhost:7711"
+reporter.wso2sp.publisher.databridge.agent.config="/Users/ramindu/wso2/git/sinthuja/msf4j/samples/message-tracing/open-tracing/src/main/resources/data.agent.config.yaml"
+javax.net.ssl.trustStore="/Users/ramindu/wso2/git/sinthuja/msf4j/samples/message-tracing/open-tracing/src/main/resources/wso2carbon.jks"
+javax.net.ssl.trustStorePassword="wso2carbon"
+reporter.wso2sp.publisher.service.name="ballerina_hello_world"
+```
+- Run your Ballerina service with that `ballerina.conf` file.
+  - Either place `ballerina.conf` in your applications directory.
+  - Or use `-Bballerina.conf=path/to/ballerina.conf`
+- Once everything is up and running, you can use wso2 stream processor "Distributed Message Tracer" dashboard to view traces.

--- a/tracing-extensions/modules/ballerina-sp-extension/README.md
+++ b/tracing-extensions/modules/ballerina-sp-extension/README.md
@@ -15,15 +15,15 @@ name="wso2sp"
 [b7a.observability.tracing.wso2sp]
 reporter.wso2sp.publisher.type="thrift"
 reporter.wso2sp.publisher.username="admin"
-reporter.wso2sp.publisher.password="admin"
+reporter.wso2sp.publisher.password="*****"
 reporter.wso2sp.publisher.url="tcp://localhost:7611"
 reporter.wso2sp.publisher.authUrl="ssl://localhost:7711"
-reporter.wso2sp.publisher.databridge.agent.config="/Users/ramindu/wso2/git/sinthuja/msf4j/samples/message-tracing/open-tracing/src/main/resources/data.agent.config.yaml"
-javax.net.ssl.trustStore="/Users/ramindu/wso2/git/sinthuja/msf4j/samples/message-tracing/open-tracing/src/main/resources/wso2carbon.jks"
-javax.net.ssl.trustStorePassword="wso2carbon"
+reporter.wso2sp.publisher.databridge.agent.config="/Users/wso2/resources/data.agent.config.yaml"
+javax.net.ssl.trustStore="/Users/wso2/resources/wso2carbon.jks"
+javax.net.ssl.trustStorePassword="*****"
 reporter.wso2sp.publisher.service.name="ballerina_hello_world"
 ```
 - Run your Ballerina service with that `ballerina.conf` file.
   - Either place `ballerina.conf` in your applications directory.
-  - Or use `-Bballerina.conf=path/to/ballerina.conf`
+  - Or use `--config path/to/ballerina.conf`
 - Once everything is up and running, you can use wso2 stream processor "Distributed Message Tracer" dashboard to view traces.

--- a/tracing-extensions/modules/ballerina-sp-extension/pom.xml
+++ b/tracing-extensions/modules/ballerina-sp-extension/pom.xml
@@ -48,6 +48,24 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <effort>Max</effort>
+                    <threshold>Low</threshold>
+                    <failOnError>true</failOnError>
+                    <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
+                    <plugins>
+                        <plugin>
+                            <groupId>com.h3xstream.findsecbugs</groupId>
+                            <artifactId>findsecbugs-plugin</artifactId>
+                            <version>LATEST</version> <!-- Auto-update to the latest stable -->
+                        </plugin>
+                    </plugins>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptors>

--- a/tracing-extensions/modules/ballerina-sp-extension/pom.xml
+++ b/tracing-extensions/modules/ballerina-sp-extension/pom.xml
@@ -40,7 +40,7 @@
             <artifactId>opentracing-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.sp</groupId>
+            <groupId>org.wso2.carbon.analytics</groupId>
             <artifactId>org.wso2.sp.open.tracer.client</artifactId>
         </dependency>
     </dependencies>

--- a/tracing-extensions/modules/ballerina-sp-extension/pom.xml
+++ b/tracing-extensions/modules/ballerina-sp-extension/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.ballerinalang</groupId>
+        <artifactId>tracing-extensions</artifactId>
+        <version>0.972.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>ballerina-sp-extension</artifactId>
+    <name>Ballerina - Stream Processor Tracing Extension</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.ballerinalang</groupId>
+            <artifactId>ballerina-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.sp</groupId>
+            <artifactId>org.wso2.sp.open.tracer.client</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/dist.xml</descriptor>
+                    </descriptors>
+                    <finalName>distribution</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-remote-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <configuration>
+                            <resourceBundles>
+                                <resourceBundle>org.apache:apache-jar-resource-bundle:1.4</resourceBundle>
+                            </resourceBundles>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tracing-extensions/modules/ballerina-sp-extension/spotbugs-exclude.xml
+++ b/tracing-extensions/modules/ballerina-sp-extension/spotbugs-exclude.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter>
+
+</FindBugsFilter>

--- a/tracing-extensions/modules/ballerina-sp-extension/src/main/assembly/dist.xml
+++ b/tracing-extensions/modules/ballerina-sp-extension/src/main/assembly/dist.xml
@@ -1,0 +1,43 @@
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<assembly>
+    <id>distribution</id>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <formats>
+        <format>zip</format>
+    </formats>
+
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory></outputDirectory>
+            <scope>runtime</scope>
+            <includes>
+                <include>org.wso2.sp:org.wso2.sp.open.tracer.client:jar</include>
+                <include>org.ballerinalang:ballerina-sp-extension:jar</include>
+                <include>org.wso2.carbon.analytics-common:org.wso2.carbon.databridge.agent</include>
+                <include>org.wso2.carbon.analytics-common:org.wso2.carbon.databridge.commons</include>
+                <include>org.apache.log4j.wso2:log4j</include>
+                <include>org.wso2.carbon.config:org.wso2.carbon.config</include>
+                <include>org.wso2.carbon.secvault:org.wso2.carbon.secvault</include>
+                <include>org.wso2.carbon.analytics-common:org.wso2.carbon.databridge.commons.thrift</include>
+                <include>io.opentracing:opentracing-api</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+
+</assembly>

--- a/tracing-extensions/modules/ballerina-sp-extension/src/main/assembly/dist.xml
+++ b/tracing-extensions/modules/ballerina-sp-extension/src/main/assembly/dist.xml
@@ -35,7 +35,7 @@
                 <include>org.wso2.carbon.config:org.wso2.carbon.config</include>
                 <include>org.wso2.carbon.secvault:org.wso2.carbon.secvault</include>
                 <include>org.wso2.carbon.analytics-common:org.wso2.carbon.databridge.commons.thrift</include>
-                <include>io.opentracing:opentracing-api</include>
+                <include>org.json.wso2:json</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/tracing-extensions/modules/ballerina-sp-extension/src/main/java/org/ballerinalang/observe/trace/extension/wso2sp/Constants.java
+++ b/tracing-extensions/modules/ballerina-sp-extension/src/main/java/org/ballerinalang/observe/trace/extension/wso2sp/Constants.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.observe.trace.extension.wso2sp;
+
+/**
+ * This is the constants class that defines all the constants
+ * that are used by the {@link OpenTracingExtension}.
+ */
+public class Constants {
+    static final String WSO2SP_REPORTER_PUBLISHER_TYPE = "reporter.wso2sp.publisher.type";
+    static final String WSO2SP_REPORTER_USERNAME = "reporter.wso2sp.publisher.username";
+    static final String WSO2SP_REPORTER_PASSWORD = "reporter.wso2sp.publisher.password";
+    static final String WSO2SP_REPORTER_URL = "reporter.wso2sp.publisher.url";
+    static final String WSO2SP_REPORTER_AUTHURL = "reporter.wso2sp.publisher.authUrl";
+    static final String WSO2SP_REPORTER_SERVICE_NAME = "reporter.wso2sp.publisher.service.name";
+    static final String WSO2SP_REPORTER_DATABRIDGE_AGENT_CONFIG = "reporter.wso2sp.publisher.databridge.agent.config";
+    static final String WSO2SP_REPORTER_TRUSTSTORE = "javax.net.ssl.trustStore";
+    static final String WSO2SP_REPORTER_TRUSTSTORE_PASSWORD = "javax.net.ssl.trustStorePassword";
+    static final String DEFAULT_WSO2SP_REPORTER_PUBLISHER_TYPE_CONFIG = "thrift";
+    static final String DEFAULT_WSO2SP_REPORTER_USERNAME = "admin";
+    static final String DEFAULT_WSO2SP_REPORTER_PASSWORD = "admin";
+    static final String DEFAULT_WSO2SP_REPORTER_URL = "tcp://localhost:7611";
+    static final String DEFAULT_WSO2SP_REPORTER_AUTHURL = "ssl://localhost:7711";
+    static final String DEFAULT_WSO2SP_REPORTER_SERVICE_NAME = "wso2_ballerina";
+    static final String DEFAULT_WSO2SP_REPORTER_TRUSTSTORE_PASSWORD = "wso2carbon";
+    private Constants() {
+
+    }
+}

--- a/tracing-extensions/modules/ballerina-sp-extension/src/main/java/org/ballerinalang/observe/trace/extension/wso2sp/Constants.java
+++ b/tracing-extensions/modules/ballerina-sp-extension/src/main/java/org/ballerinalang/observe/trace/extension/wso2sp/Constants.java
@@ -34,11 +34,9 @@ public class Constants {
     static final String WSO2SP_REPORTER_TRUSTSTORE_PASSWORD = "javax.net.ssl.trustStorePassword";
     static final String DEFAULT_WSO2SP_REPORTER_PUBLISHER_TYPE_CONFIG = "thrift";
     static final String DEFAULT_WSO2SP_REPORTER_USERNAME = "admin";
-    static final String DEFAULT_WSO2SP_REPORTER_PASSWORD = "admin";
     static final String DEFAULT_WSO2SP_REPORTER_URL = "tcp://localhost:7611";
     static final String DEFAULT_WSO2SP_REPORTER_AUTHURL = "ssl://localhost:7711";
     static final String DEFAULT_WSO2SP_REPORTER_SERVICE_NAME = "wso2_ballerina";
-    static final String DEFAULT_WSO2SP_REPORTER_TRUSTSTORE_PASSWORD = "wso2carbon";
     private Constants() {
 
     }

--- a/tracing-extensions/modules/ballerina-sp-extension/src/main/java/org/ballerinalang/observe/trace/extension/wso2sp/NoOpScopeManager.java
+++ b/tracing-extensions/modules/ballerina-sp-extension/src/main/java/org/ballerinalang/observe/trace/extension/wso2sp/NoOpScopeManager.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.observe.trace.extension.wso2sp;
+
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * NoOp implementation of Scope Manager.
+ */
+public class NoOpScopeManager implements ScopeManager {
+
+    static final NoOpScopeManager INSTANCE = new NoOpScopeManager();
+
+    private NoOpScopeManager() {
+    }
+
+    @Override
+    public Scope activate(Span span, boolean finishSpanOnClose) {
+        return NoOpScope.INSTANCE;
+    }
+
+    @Override
+    public Scope active() {
+        return null;
+    }
+
+    static class NoOpScope implements Scope {
+
+        static final NoOpScope INSTANCE = new NoOpScope();
+
+        private NoOpScope() {
+        }
+
+        @Override
+        public void close() {
+
+        }
+
+        @Override
+        public Span span() {
+            return NoOpSpan.INSTANCE;
+        }
+    }
+
+    static class NoOpSpan implements Span {
+
+        static final NoOpSpan INSTANCE = new NoOpSpan();
+
+        private NoOpSpan() {
+        }
+
+        @Override
+        public SpanContext context() {
+            return NoOpSpanContext.INSTANCE;
+        }
+
+        @Override
+        public void finish() {
+        }
+
+        @Override
+        public void finish(long finishMicros) {
+        }
+
+        @Override
+        public NoOpSpan setTag(String key, String value) {
+            return this;
+        }
+
+        @Override
+        public NoOpSpan setTag(String key, boolean value) {
+            return this;
+        }
+
+        @Override
+        public NoOpSpan setTag(String key, Number value) {
+            return this;
+        }
+
+        @Override
+        public NoOpSpan log(Map<String, ?> fields) {
+            return this;
+        }
+
+        @Override
+        public NoOpSpan log(long timestampMicroseconds, Map<String, ?> fields) {
+            return this;
+        }
+
+        @Override
+        public NoOpSpan log(String event) {
+            return this;
+        }
+
+        @Override
+        public NoOpSpan log(long timestampMicroseconds, String event) {
+            return this;
+        }
+
+        @Override
+        public NoOpSpan setBaggageItem(String key, String value) {
+            return this;
+        }
+
+        @Override
+        public String getBaggageItem(String key) {
+            return null;
+        }
+
+        @Override
+        public NoOpSpan setOperationName(String operationName) {
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return NoOpSpan.class.getSimpleName();
+        }
+    }
+
+    static class NoOpSpanContext implements SpanContext {
+
+        static final NoOpSpanContext INSTANCE = new NoOpSpanContext();
+
+        private NoOpSpanContext() {
+        }
+
+        @Override
+        public Iterable<Map.Entry<String, String>> baggageItems() {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/tracing-extensions/modules/ballerina-sp-extension/src/main/java/org/ballerinalang/observe/trace/extension/wso2sp/OpenTracingExtension.java
+++ b/tracing-extensions/modules/ballerina-sp-extension/src/main/java/org/ballerinalang/observe/trace/extension/wso2sp/OpenTracingExtension.java
@@ -32,14 +32,12 @@ import java.util.Properties;
 
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_AUTHURL;
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_PUBLISHER_TYPE_CONFIG;
-import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_SERVICE_NAME;
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_URL;
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_USERNAME;
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_AUTHURL;
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_DATABRIDGE_AGENT_CONFIG;
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_PASSWORD;
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_PUBLISHER_TYPE;
-import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_SERVICE_NAME;
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_TRUSTSTORE;
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_TRUSTSTORE_PASSWORD;
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_URL;
@@ -101,9 +99,6 @@ public class OpenTracingExtension implements OpenTracer {
 
     @Override
     public Tracer getTracer(String tracerName, String serviceName) {
-        tracerProperties.setProperty(WSO2SP_REPORTER_SERVICE_NAME,
-                configRegistry.getConfigOrDefault(getFullQualifiedConfig
-                        (WSO2SP_REPORTER_SERVICE_NAME), DEFAULT_WSO2SP_REPORTER_SERVICE_NAME));
         try {
             return this.streamProcessorTracerClient.getTracer(serviceName, NoOpScopeManager.INSTANCE);
         } catch (AnalyticsTracerInitializationException e) {

--- a/tracing-extensions/modules/ballerina-sp-extension/src/main/java/org/ballerinalang/observe/trace/extension/wso2sp/OpenTracingExtension.java
+++ b/tracing-extensions/modules/ballerina-sp-extension/src/main/java/org/ballerinalang/observe/trace/extension/wso2sp/OpenTracingExtension.java
@@ -79,7 +79,6 @@ public class OpenTracingExtension implements OpenTracer {
         tracerProperties.setProperty(WSO2SP_REPORTER_AUTHURL,
                 configRegistry.getConfigOrDefault(getFullQualifiedConfig
                         (WSO2SP_REPORTER_AUTHURL), DEFAULT_WSO2SP_REPORTER_AUTHURL));
-
         tracerProperties.setProperty(WSO2SP_REPORTER_DATABRIDGE_AGENT_CONFIG,
                 configRegistry.getConfigOrDefault(getFullQualifiedConfig(WSO2SP_REPORTER_DATABRIDGE_AGENT_CONFIG),
                         null));
@@ -89,7 +88,6 @@ public class OpenTracingExtension implements OpenTracer {
         tracerProperties.setProperty(WSO2SP_REPORTER_TRUSTSTORE_PASSWORD,
                 configRegistry.getConfigOrDefault(getFullQualifiedConfig(WSO2SP_REPORTER_TRUSTSTORE_PASSWORD),
                         null));
-
         tracerProperties.setProperty(TRACER_NAME, TRACER_VALUE);
         try {
             this.streamProcessorTracerClient.init(tracerProperties);

--- a/tracing-extensions/modules/ballerina-sp-extension/src/main/java/org/ballerinalang/observe/trace/extension/wso2sp/OpenTracingExtension.java
+++ b/tracing-extensions/modules/ballerina-sp-extension/src/main/java/org/ballerinalang/observe/trace/extension/wso2sp/OpenTracingExtension.java
@@ -31,10 +31,8 @@ import java.io.PrintStream;
 import java.util.Properties;
 
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_AUTHURL;
-import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_PASSWORD;
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_PUBLISHER_TYPE_CONFIG;
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_SERVICE_NAME;
-import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_TRUSTSTORE_PASSWORD;
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_URL;
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_USERNAME;
 import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_AUTHURL;
@@ -71,7 +69,7 @@ public class OpenTracingExtension implements OpenTracer {
                         (WSO2SP_REPORTER_USERNAME), DEFAULT_WSO2SP_REPORTER_USERNAME));
         tracerProperties.setProperty(WSO2SP_REPORTER_PASSWORD,
                 configRegistry.getConfigOrDefault(getFullQualifiedConfig
-                        (WSO2SP_REPORTER_PASSWORD), DEFAULT_WSO2SP_REPORTER_PASSWORD));
+                        (WSO2SP_REPORTER_PASSWORD), null));
         tracerProperties.setProperty(WSO2SP_REPORTER_URL,
                 configRegistry.getConfigOrDefault(getFullQualifiedConfig
                         (WSO2SP_REPORTER_URL), DEFAULT_WSO2SP_REPORTER_URL));
@@ -90,7 +88,7 @@ public class OpenTracingExtension implements OpenTracer {
                         null));
         tracerProperties.setProperty(WSO2SP_REPORTER_TRUSTSTORE_PASSWORD,
                 configRegistry.getConfigOrDefault(getFullQualifiedConfig(WSO2SP_REPORTER_TRUSTSTORE_PASSWORD),
-                        DEFAULT_WSO2SP_REPORTER_TRUSTSTORE_PASSWORD));
+                        null));
 
         tracerProperties.setProperty(TRACER_NAME, TRACER_VALUE);
         try {

--- a/tracing-extensions/modules/ballerina-sp-extension/src/main/java/org/ballerinalang/observe/trace/extension/wso2sp/OpenTracingExtension.java
+++ b/tracing-extensions/modules/ballerina-sp-extension/src/main/java/org/ballerinalang/observe/trace/extension/wso2sp/OpenTracingExtension.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.observe.trace.extension.wso2sp;
+
+import io.opentracing.Tracer;
+import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.config.ConfigRegistry;
+import org.ballerinalang.util.observability.ObservabilityConstants;
+import org.ballerinalang.util.tracer.OpenTracer;
+import org.ballerinalang.util.tracer.exception.InvalidConfigurationException;
+import org.wso2.sp.open.tracer.client.AnalyticsTracerInitializationException;
+import org.wso2.sp.open.tracer.client.InvalidTracerConfigurationException;
+import org.wso2.sp.open.tracer.client.StreamProcessorTracerClient;
+
+import java.io.PrintStream;
+import java.util.Properties;
+
+import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_AUTHURL;
+import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_PASSWORD;
+import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_PUBLISHER_TYPE_CONFIG;
+import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_SERVICE_NAME;
+import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_TRUSTSTORE_PASSWORD;
+import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_URL;
+import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.DEFAULT_WSO2SP_REPORTER_USERNAME;
+import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_AUTHURL;
+import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_DATABRIDGE_AGENT_CONFIG;
+import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_PASSWORD;
+import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_PUBLISHER_TYPE;
+import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_SERVICE_NAME;
+import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_TRUSTSTORE;
+import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_TRUSTSTORE_PASSWORD;
+import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_URL;
+import static org.ballerinalang.observe.trace.extension.wso2sp.Constants.WSO2SP_REPORTER_USERNAME;
+
+/**
+ * This is the open tracing extension class for {@link OpenTracer}.
+ */
+@JavaSPIService("org.ballerinalang.util.tracer.OpenTracer")
+public class OpenTracingExtension implements OpenTracer {
+    private static final PrintStream console = System.out;
+    private static final String TRACER_NAME = "trace.name";
+    private static final String TRACER_VALUE = "wso2sp";
+    private ConfigRegistry configRegistry;
+    private Properties tracerProperties;
+    private StreamProcessorTracerClient streamProcessorTracerClient;
+    @Override
+    public void init() throws InvalidConfigurationException {
+        this.streamProcessorTracerClient = new StreamProcessorTracerClient();
+        configRegistry = ConfigRegistry.getInstance();
+        tracerProperties = new Properties();
+        tracerProperties.setProperty(WSO2SP_REPORTER_PUBLISHER_TYPE,
+                configRegistry.getConfigOrDefault(getFullQualifiedConfig(
+                        WSO2SP_REPORTER_PUBLISHER_TYPE), DEFAULT_WSO2SP_REPORTER_PUBLISHER_TYPE_CONFIG));
+        tracerProperties.setProperty(WSO2SP_REPORTER_USERNAME,
+                configRegistry.getConfigOrDefault(getFullQualifiedConfig
+                        (WSO2SP_REPORTER_USERNAME), DEFAULT_WSO2SP_REPORTER_USERNAME));
+        tracerProperties.setProperty(WSO2SP_REPORTER_PASSWORD,
+                configRegistry.getConfigOrDefault(getFullQualifiedConfig
+                        (WSO2SP_REPORTER_PASSWORD), DEFAULT_WSO2SP_REPORTER_PASSWORD));
+        tracerProperties.setProperty(WSO2SP_REPORTER_URL,
+                configRegistry.getConfigOrDefault(getFullQualifiedConfig
+                        (WSO2SP_REPORTER_URL), DEFAULT_WSO2SP_REPORTER_URL));
+        tracerProperties.setProperty(WSO2SP_REPORTER_AUTHURL,
+                configRegistry.getConfigOrDefault(getFullQualifiedConfig
+                        (WSO2SP_REPORTER_AUTHURL), DEFAULT_WSO2SP_REPORTER_AUTHURL));
+        tracerProperties.setProperty(WSO2SP_REPORTER_AUTHURL,
+                configRegistry.getConfigOrDefault(getFullQualifiedConfig
+                        (WSO2SP_REPORTER_AUTHURL), DEFAULT_WSO2SP_REPORTER_AUTHURL));
+
+        tracerProperties.setProperty(WSO2SP_REPORTER_DATABRIDGE_AGENT_CONFIG,
+                configRegistry.getConfigOrDefault(getFullQualifiedConfig(WSO2SP_REPORTER_DATABRIDGE_AGENT_CONFIG),
+                        null));
+        tracerProperties.setProperty(WSO2SP_REPORTER_TRUSTSTORE,
+                configRegistry.getConfigOrDefault(getFullQualifiedConfig(WSO2SP_REPORTER_TRUSTSTORE),
+                        null));
+        tracerProperties.setProperty(WSO2SP_REPORTER_TRUSTSTORE_PASSWORD,
+                configRegistry.getConfigOrDefault(getFullQualifiedConfig(WSO2SP_REPORTER_TRUSTSTORE_PASSWORD),
+                        DEFAULT_WSO2SP_REPORTER_TRUSTSTORE_PASSWORD));
+
+        tracerProperties.setProperty(TRACER_NAME, TRACER_VALUE);
+        try {
+            this.streamProcessorTracerClient.init(tracerProperties);
+        } catch (InvalidTracerConfigurationException e) {
+            throw new InvalidConfigurationException(e.getMessage());
+        }
+        console.println("ballerina: started publishing tracers to WSO2 Stream Processor on " +
+                tracerProperties.getProperty(WSO2SP_REPORTER_URL) + " via " +
+                tracerProperties.getProperty(WSO2SP_REPORTER_PUBLISHER_TYPE));
+    }
+
+    @Override
+    public Tracer getTracer(String tracerName, String serviceName) {
+        tracerProperties.setProperty(WSO2SP_REPORTER_SERVICE_NAME,
+                configRegistry.getConfigOrDefault(getFullQualifiedConfig
+                        (WSO2SP_REPORTER_SERVICE_NAME), DEFAULT_WSO2SP_REPORTER_SERVICE_NAME));
+        try {
+            return this.streamProcessorTracerClient.getTracer(serviceName, NoOpScopeManager.INSTANCE);
+        } catch (AnalyticsTracerInitializationException e) {
+            console.println("Unable to initialize the " + tracerName + " tracer. " + e.getCause());
+        }
+        return null;
+    }
+
+    private String getFullQualifiedConfig(String configName) {
+        return ObservabilityConstants.CONFIG_TABLE_TRACING + "." + TRACER_VALUE + "." + configName;
+    }
+
+    @Override
+    public String getName() {
+        return TRACER_VALUE;
+    }
+}

--- a/tracing-extensions/pom.xml
+++ b/tracing-extensions/pom.xml
@@ -37,6 +37,7 @@
         <module>modules/ballerina-jaeger-extension</module>
         <module>modules/ballerina-zipkin-extension</module>
         <module>modules/ballerina-noop-extension</module>
+        <module>modules/ballerina-sp-extension</module>
     </modules>
 
 </project>


### PR DESCRIPTION
## Purpose
> Publish open-tracing standardise messages to WSO2 Stream Processor from ballerina

## Goals
> Ballerina services will be able to publish to WSO2 Stream Processor for analyzing message traces.
<img width="1440" alt="screen shot 2018-07-13 at 4 39 25 pm" src="https://user-images.githubusercontent.com/10056966/42688791-562ffe90-86bb-11e8-957a-a8b3c82aceb5.png">

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes