### PR TITLE
Update in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -580,7 +580,7 @@
         <brave.zipkin.version>4.17.1</brave.zipkin.version>
         <zipkin.reporter.version>2.5.0</zipkin.reporter.version>
         <zipkin.version>2.6.1</zipkin.version>
-        <analytics.solutions.version>1.0.8</analytics.solutions.version>
+        <analytics.solutions.version>1.0.12</analytics.solutions.version>
         <carbon.analytics-common.version>6.0.64</carbon.analytics-common.version>
         <org.wso2.json.version>3.0.0.wso2v1</org.wso2.json.version>
         <wso2.log4j.version>1.2.17.wso2v1</wso2.log4j.version>


### PR DESCRIPTION
## Purpose
> Timestamp issue while observing traces in distributed message tracer using sp-extension has been removed by using org.wso2.sp.open.tracer.client-1.0.12 version instead of version 1.0.8 .