### PR TITLE
Bump okhttp version to v3.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -574,7 +574,7 @@
         <open.tracing.version>0.31.0</open.tracing.version>
         <jaeger.version>0.24.0</jaeger.version>
         <libthrift.version>0.12.0</libthrift.version>
-        <okhttp.version>3.9.1</okhttp.version>
+        <okhttp.version>3.13.1</okhttp.version>
         <okio.version>1.13.0</okio.version>
         <brave.open.tracing.version>0.29.0</brave.open.tracing.version>
         <brave.zipkin.version>4.17.1</brave.zipkin.version>


### PR DESCRIPTION
## Purpose
Purpose of this PR is to Bump okhttp version to v3.13.1.
