### PR TITLE
Add missing Brave dependency required by Zipkin Tracer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,11 @@
                 <version>${brave.open.tracing.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.zipkin.brave</groupId>
+                <artifactId>brave</artifactId>
+                <version>${brave.zipkin.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.zipkin.reporter2</groupId>
                 <artifactId>zipkin-reporter</artifactId>
                 <version>${zipkin.reporter.version}</version>

--- a/tracing-extensions/modules/ballerina-zipkin-extension/pom.xml
+++ b/tracing-extensions/modules/ballerina-zipkin-extension/pom.xml
@@ -52,6 +52,10 @@
             <artifactId>brave-opentracing</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.zipkin.reporter2</groupId>
             <artifactId>zipkin-reporter</artifactId>
         </dependency>


### PR DESCRIPTION
## Purpose
> Without the Brave Tracing dependency, generating the Zipkin Brave Tracer will throw a no class definition found exception. This causes the Zipkin tracing to not work properly.

## Goals
> Add dependency required for avoiding no class definition found exception.

## Approach
> Add missing dependency.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A